### PR TITLE
Use reference-style links in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,15 @@ Once you have an account, it must be provisioned for the following two items:
 1. **Integration ID**
 
    To create an integration, follow the instructions in [Creating an Omni SDK
-   Integration]
-   (https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html).
-   The two services you can enable there (**Messaging** and **WebRTC Voice**)
-   each correspond to a client SDK module, and you must enable the services for
-   the modules that you will use.
+   Integration][omni-integration]. The two services you can enable there
+   (**Messaging** and **WebRTC Voice**) each correspond to a client SDK module,
+   and you must enable the services for the modules that you will use.
 
 2. **Application Key**
 
    To enable remote access to the AXP APIs, you need to get an application key
-   as described in [How to Authenticate with Avaya Experience Platform™ APIs]
-   (https://developers.avayacloud.com/avaya-experience-platform/docs/how-to-authenticate-with-axp-apis).
+   as described in [How to Authenticate with Avaya Experience Platform™
+   APIs][axp-auth].
 
 ## License
 
@@ -41,3 +39,6 @@ View [LICENSE](./LICENSE)
 ## Changelog
 
 View [CHANGELOG.md](./CHANGELOG.md)
+
+[omni-integration]: https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html
+[axp-auth]: https://developers.avayacloud.com/avaya-experience-platform/docs/how-to-authenticate-with-axp-apis

--- a/calling.md
+++ b/calling.md
@@ -10,10 +10,9 @@ depends on the Core module for configuring the SDK and authenticating with AXP.
 
 To use the Calling module, you need an Omni SDK integration provisioned with
 the **WebRTC Voice** service enabled. Follow the instructions in
-[Creating an Omni SDK Integration]
-(https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html)
-to set up an integration with voice support and use the integration ID for
-configuring the SDK as described in the documentation for the Core module.
+[Creating an Omni SDK Integration][omni-integration] to set up an integration
+with voice support and use the integration ID for configuring the SDK as
+described in the documentation for the Core module.
 
 ## Installation
 
@@ -30,9 +29,7 @@ To download packages from the GitHub registry, you first need to generate an
 authentication token for your GitHub account.
 
 To generate one, follow the instructions from [Creating a personal access token
-(classic)]
-(https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
-For the selected scopes, pick "read:packages".
+(classic)][gh-token]. For the selected scopes, pick "read:packages".
 
 #### Add Repository
 
@@ -100,14 +97,10 @@ Replace `${avayaSdkVersion}` with the latest version of the AXP SDK.
 ### Manual Installation
 
 If you don't have or wish to use a GitHub account, you can download the package
-manually from [its package page]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150736)
+manually from [its package page][package].
 
-You'll also need to download the [Core module]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727)
-and [calling helper library]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150734)
-that it depends on.
+You'll also need to download the [Core module][core-package] and [calling helper
+library][mpaas-package] that it depends on.
 
 #### Include Package
 
@@ -222,9 +215,8 @@ To support this in your app, you need to do two things:
 
 ## Jetpack Telecom Integration
 
-The AXP Calling SDK has integration with Google's [Jetpack Telecom API]
-(https://developer.android.com/develop/connectivity/telecom/voip-app/telecom)
-to simplify writing calling applications.
+The AXP Calling SDK has integration with Google's [Jetpack Telecom
+API][telecom-api] to simplify writing calling applications.
 
 The SDK already implements everything needed for calling with Jetpack Telecom.
 To use it, in your application, instead of starting calls manually as described
@@ -234,3 +226,10 @@ to trigger the call service, which calls into the AXP SDK APIs to start the call
 on the default conversation. It takes the same parameters as `addCall`.
 
 # Package com.avaya.axp.client.sdk.webrtc
+
+[omni-integration]: https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html
+[gh-token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150736
+[core-package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727
+[mpaas-package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150734
+[telecom-api]: https://developer.android.com/develop/connectivity/telecom/voip-app/telecom

--- a/core.md
+++ b/core.md
@@ -28,11 +28,9 @@ Once you have an account, it must be provisioned for the following two items:
 1. **Integration ID**
 
    To create an integration, follow the instructions in [Creating an Omni SDK
-   Integration]
-   (https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html).
-   The two services you can enable there (**Messaging** and **WebRTC Voice**)
-   each correspond to a client SDK module, and you must enable the services for
-   the modules that you will use.
+   Integration][omni-integration]. The two services you can enable there
+   (**Messaging** and **WebRTC Voice**) each correspond to a client SDK module,
+   and you must enable the services for the modules that you will use.
 
    Note the integration ID that is created, as you will need to provide it when
    configuring the SDK as described below.
@@ -40,8 +38,8 @@ Once you have an account, it must be provisioned for the following two items:
 2. **Application Key**
 
    To enable remote access to the AXP APIs, you need to get an application key
-   as described in [How to Authenticate with Avaya Experience Platform™ APIs]
-   (https://developers.avayacloud.com/avaya-experience-platform/docs/how-to-authenticate-with-axp-apis).
+   as described in [How to Authenticate with Avaya Experience Platform™
+   APIs][axp-auth].
 
    Note the application key that is created, as you will need to provide it when
    configuring the SDK as described below.
@@ -61,9 +59,7 @@ To download packages from the GitHub registry, you first need to generate an
 authentication token for your GitHub account.
 
 To generate one, follow the instructions from [Creating a personal access token
-(classic)]
-(https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
-For the selected scopes, pick "read:packages".
+(classic)][gh-token]. For the selected scopes, pick "read:packages".
 
 #### Add Repository
 
@@ -127,8 +123,7 @@ Replace `${avayaSdkVersion}` with the latest version of the AXP SDK.
 ### Manual Installation
 
 If you don't have or wish to use a GitHub account, you can download the package
-manually from [its package page]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727)
+manually from [its package page][package].
 
 #### Include Package
 
@@ -313,3 +308,8 @@ but if there is an error it will be communicated via the `AxpResult` or
 used afterwards.
 
 # Package com.avaya.axp.client.sdk
+
+[omni-integration]: https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html
+[axp-auth]: https://developers.avayacloud.com/avaya-experience-platform/docs/how-to-authenticate-with-axp-apis
+[gh-token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727

--- a/messaging-ui.md
+++ b/messaging-ui.md
@@ -79,9 +79,7 @@ To download packages from the GitHub registry, you first need to generate an
 authentication token for your GitHub account.
 
 To generate one, follow the instructions from [Creating a personal access token
-(classic)]
-(https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
-For the selected scopes, pick "read:packages".
+(classic)][gh-token]. For the selected scopes, pick "read:packages".
 
 #### Add Repository
 
@@ -149,14 +147,10 @@ Replace `${avayaSdkVersion}` with the latest version of the AXP SDK.
 ### Manual Installation
 
 If you don't have or wish to use a GitHub account, you can download the package
-manually from [its package page]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150733)
+manually from [its package page][package].
 
-You'll also need to download the [Core module]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727)
-and [Messaging Module]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150732)
-that it depends on.
+You'll also need to download the [Core module][core-package]
+and [Messaging Module][messaging-package] that it depends on.
 
 #### Include Package
 
@@ -192,12 +186,6 @@ Replace `${avayaSdkVersion}` with the version number of the AXP SDK and
 
 ### Flags:
 
-- `autoDownloadImages` :
-  Set this flag to true if you want to automatically download Images.
-- `autoDownloadMediaFiles` :
-  Set this flag to true if you want to automatically download Media Files.
-- `mediaSavePath` :
-  Directory path where you want to save downloaded media files or will be saved in Downloads folder.  
 - `showAgentEvents` :
   Set this flag to true if you want to show the agent joined and left events in the messaging window.
 - `showAutomationEvents` :
@@ -208,13 +196,9 @@ Replace `${avayaSdkVersion}` with the version number of the AXP SDK and
   Set this flag to true if you want to show the active participants list in the messaging window.
 - `useBusinessAsParticipant` :
   Set this flag to true if you want to use business as a participant in the messaging window.
-- `showIdleTimeoutDialog` :
-  Set this flag to true if you want to show the idle timeout dialog in the messaging window when there is no activity from customer.
 
 ### Functions:
 
-- `init()`
-  starts observing idle timeout and events stream state / server connection state.
 - `setUiThemeLight()`
   Set the UI theme to light.
 - `setUiThemeDark()`
@@ -246,16 +230,12 @@ The `ConversationHandler` exposes essential properties and methods for developer
 
 - `getLocationDetails(onComplete:(LocationMessage?)->Unit)`: The app should fetch the location and call the `onComplete` method with the location details. If it fails to fetch the location details, it should call the `onComplete` method with `null`.
 - `getLocationUrl(latitude:Double?,longitude:Double?):String` : The app should provide the location URL using latitude and longitude. When clicked, the user will be directed to maps or a browser.
-- `GetLocationMapWidget(latitude:Double?,longitude:Double?)` : This Composable function  is used to get the location map widget.
 
 ### Show Messaging UI
 
 - To show the messaging UI, you can use the `ShowMessagingUI(conversationHandler: ConversationHandler)` composable function. You can pass the conversation handler object to this function and the UI for that conversation will be rendered on the Messaging screen.  
 
-### Permissions
-
-- To use all the features of ui sdk, you need to give permissions for camera, audio recording and notifications. You can do it manually by going to app info or you can add mechanism to give permission at runtime.
-
-### Push notifications
-- Generate and add google-services.json file in sample-app-messaging directory 
-- Enable permission for notifications
+[gh-token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150733
+[core-package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727
+[messaging-package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150732

--- a/messaging.md
+++ b/messaging.md
@@ -12,10 +12,9 @@ closed after the participants disconnect the dialog.
 
 To use the Messaging module, you need an Omni SDK integration provisioned with
 the **Messaging** service enabled. Follow the instructions in
-[Creating an Omni SDK Integration]
-(https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html)
-to set up an integration with messaging support and use the integration ID for
-configuring the SDK as described in the documentation for the Core module.
+[Creating an Omni SDK Integration][omni-integration] to set up an integration
+with messaging support and use the integration ID for configuring the SDK as
+described in the documentation for the Core module.
 
 ## Installation
 
@@ -32,9 +31,7 @@ To download packages from the GitHub registry, you first need to generate an
 authentication token for your GitHub account.
 
 To generate one, follow the instructions from [Creating a personal access token
-(classic)]
-(https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
-For the selected scopes, pick "read:packages".
+(classic)][gh-token]. For the selected scopes, pick "read:packages".
 
 #### Add Repository
 
@@ -100,12 +97,9 @@ Replace `${avayaSdkVersion}` with the latest version of the AXP SDK.
 ### Manual Installation
 
 If you don't have or wish to use a GitHub account, you can download the package
-manually from [its package page]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150732)
+manually from [its package page][package].
 
-You'll also need to download the [Core module]
-(https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727)
-that it depends on.
+You'll also need to download the [Core module][core-package] that it depends on.
 
 #### Include Package
 
@@ -306,3 +300,8 @@ val messagingParticipants = conversation.participants(AxpChannel.MESSAGING)
 ```
 
 # Package com.avaya.axp.client.sdk.messaging
+
+[omni-integration]: https://documentation.avaya.com/bundle/ExperiencePlatform_Administering_10/page/Creating_an_Omni_SDK_integration.html
+[gh-token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150732
+[core-package]: https://github.com/AvayaExperiencePlatform/omni-sdk-android/packages/2150727


### PR DESCRIPTION
There cannot be a line break between the text to link and the link part of a Markdown link. Switch to reference-style links to support wrapping the source file at 80 columns.